### PR TITLE
Midi device input

### DIFF
--- a/editor/LiveInput.ts
+++ b/editor/LiveInput.ts
@@ -5,7 +5,7 @@ export class LiveInput {
 		this._doc.notifier.watch(this._documentChanged);
 		this._documentChanged();
 	}
-	private _playingPitches: {pitch: number, context: string}[] = [];
+	private _playingPitches: { pitch: number, context: string }[] = [];
 	public addNote(pitch: number, context: string) {
 		this._playingPitches = [...this._playingPitches, {pitch, context}];
 		this._updateSound();
@@ -20,7 +20,7 @@ export class LiveInput {
 		this._updateSound();
 	}
 	private _updateSound() {
-		if(this._playingPitches.length == 0) {
+		if (this._playingPitches.length == 0) {
 			this._doc.synth.liveInputDuration = 0;
 		} else {
 			this._doc.synth.liveInputDuration = Number.MAX_SAFE_INTEGER;

--- a/editor/LiveInput.ts
+++ b/editor/LiveInput.ts
@@ -5,18 +5,18 @@ export class LiveInput {
 		this._doc.notifier.watch(this._documentChanged);
 		this._documentChanged();
 	}
-	private _playingPitches: { pitch: number, context: string }[] = [];
-	public addNote(pitch: number, context: string) {
-		this._playingPitches = [...this._playingPitches, {pitch, context}];
+	private _playingPitches: number[] = [];
+	public addNote(pitch: number) {
+		this._playingPitches = [...this._playingPitches, pitch];
 		this._updateSound();
 	}
-	public removeNote(pitch: number, context: string) {
+	public removeNote(pitch: number) {
 		this._playingPitches = this._playingPitches
-			.filter(p => p.pitch !== pitch || p.context !== context);
+			.filter(p => p !== pitch);
 		this._updateSound();
 	}
-	public clear(context: string) {
-		this._playingPitches = this._playingPitches.filter(p => p.context !== context);
+	public clear() {
+		this._playingPitches = [];
 		this._updateSound();
 	}
 	private _updateSound() {
@@ -24,7 +24,7 @@ export class LiveInput {
 			this._doc.synth.liveInputDuration = 0;
 		} else {
 			this._doc.synth.liveInputDuration = Number.MAX_SAFE_INTEGER;
-			this._doc.synth.liveInputPitches = this._playingPitches.map(p => p.pitch);
+			this._doc.synth.liveInputPitches = this._playingPitches;
 			this._doc.synth.liveInputStarted = true;
 		}
 	}

--- a/editor/LiveInput.ts
+++ b/editor/LiveInput.ts
@@ -1,0 +1,30 @@
+import {SongDocument} from "./SongDocument";
+
+export class LiveInput {
+	constructor(private _doc: SongDocument) {
+		this._doc.notifier.watch(this._documentChanged);
+		this._documentChanged();
+	}
+	private _playingPitches: number[] = [];
+	public addNote(pitch: number) {
+		this._playingPitches = [...this._playingPitches, pitch];
+		this.updateSound();
+	}
+	public removeNote(pitch: number) {
+		this._playingPitches = this._playingPitches.filter(p => p !== pitch);
+		this.updateSound();
+	}
+	private updateSound() {
+		if(this._playingPitches.length == 0) {
+			this._doc.synth.liveInputDuration = 0;
+		} else {
+			this._doc.synth.liveInputDuration = Number.MAX_SAFE_INTEGER;
+			this._doc.synth.liveInputPitches = this._playingPitches;
+			this._doc.synth.liveInputStarted = true;
+		}
+	}
+	private _documentChanged = (): void => {
+		this._doc.synth.liveInputChannel = this._doc.channel;
+		this._doc.synth.liveInputInstruments = this._doc.recentPatternInstruments[this._doc.channel];
+	}
+}

--- a/editor/LiveInput.ts
+++ b/editor/LiveInput.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2012-2022 John Nesky and contributing authors, distributed under the MIT license, see accompanying the LICENSE.md file.
+
 import {SongDocument} from "./SongDocument";
 
 export class LiveInput {

--- a/editor/LiveInput.ts
+++ b/editor/LiveInput.ts
@@ -5,21 +5,26 @@ export class LiveInput {
 		this._doc.notifier.watch(this._documentChanged);
 		this._documentChanged();
 	}
-	private _playingPitches: number[] = [];
-	public addNote(pitch: number) {
-		this._playingPitches = [...this._playingPitches, pitch];
-		this.updateSound();
+	private _playingPitches: {pitch: number, context: string}[] = [];
+	public addNote(pitch: number, context: string) {
+		this._playingPitches = [...this._playingPitches, {pitch, context}];
+		this._updateSound();
 	}
-	public removeNote(pitch: number) {
-		this._playingPitches = this._playingPitches.filter(p => p !== pitch);
-		this.updateSound();
+	public removeNote(pitch: number, context: string) {
+		this._playingPitches = this._playingPitches
+			.filter(p => p.pitch !== pitch || p.context !== context);
+		this._updateSound();
 	}
-	private updateSound() {
+	public clear(context: string) {
+		this._playingPitches = this._playingPitches.filter(p => p.context !== context);
+		this._updateSound();
+	}
+	private _updateSound() {
 		if(this._playingPitches.length == 0) {
 			this._doc.synth.liveInputDuration = 0;
 		} else {
 			this._doc.synth.liveInputDuration = Number.MAX_SAFE_INTEGER;
-			this._doc.synth.liveInputPitches = this._playingPitches;
+			this._doc.synth.liveInputPitches = this._playingPitches.map(p => p.pitch);
 			this._doc.synth.liveInputStarted = true;
 		}
 	}

--- a/editor/MidiInput.ts
+++ b/editor/MidiInput.ts
@@ -17,16 +17,21 @@ interface MIDIMessageEvent {
 	target: MIDIInput;
 }
 
+declare global {
+	interface Navigator {
+		requestMIDIAccess?(): Promise<any>;
+	}
+}
+
 export class MIDIInputHandler {
 	constructor(private _doc: SongDocument, private _liveInput: LiveInput) {
 		this.registerMIDIAccessHandler();
 	}
 	private async registerMIDIAccessHandler() {
-		const requestMIDIAccess = (navigator as any).requestMIDIAccess.bind(navigator);
-		if(requestMIDIAccess == null) return;
+		if(navigator.requestMIDIAccess == null) return;
 
 		try {
-			const midiAccess = await requestMIDIAccess();
+			const midiAccess = await navigator.requestMIDIAccess();
 
 			midiAccess.inputs.forEach(this._registerMIDIInput);
 			midiAccess.addEventListener("statechange", this._handleStateChange);

--- a/editor/MidiInput.ts
+++ b/editor/MidiInput.ts
@@ -1,0 +1,82 @@
+import {SongDocument} from "./SongDocument";
+import {LiveInput} from "./LiveInput";
+
+const enum MIDI_EVENT {
+	NOTE_ON = 144,
+	NOTE_OFF = 128,
+}
+
+interface MIDIInput extends EventTarget {
+	id: string;
+	type: "input" | "output";
+	state: "disconnected" | "connected";
+}
+
+interface MIDIConnectionEvent {
+	port: MIDIInput;
+}
+
+interface MIDIMessageEvent {
+	data: [type: MIDI_EVENT, key: number, velocity: number];
+	target: MIDIInput;
+}
+
+export class MIDIInputHandler {
+	constructor(private _doc: SongDocument, private _liveInput: LiveInput) {
+		this.registerMIDIAccessHandler();
+	}
+	private async registerMIDIAccessHandler() {
+		const requestMIDIAccess = (navigator as any).requestMIDIAccess.bind(navigator);
+		if(requestMIDIAccess == null) return;
+
+		try {
+			const midiAccess = await requestMIDIAccess();
+
+			midiAccess.inputs.forEach(this._registerMIDIInput);
+			midiAccess.addEventListener("statechange", this._handleStateChange);
+		} catch(e) {
+			console.error("Failed to get MIDI access", e);
+		}
+	}
+
+	private _handleStateChange = (event: MIDIConnectionEvent) => {
+		if(event.port.type !== "input") return;
+		
+		switch(event.port.state) {
+			case "connected":
+				this._registerMIDIInput(event.port);
+				break;
+			case "disconnected":
+				this._unregisterMIDIInput(event.port);
+				break;
+		}
+	}
+
+	private _registerMIDIInput = (midiInput: MIDIInput) => {
+		midiInput.addEventListener("midimessage", this._onMIDIMessage as any);
+	}
+
+	private _unregisterMIDIInput = (midiInput: MIDIInput) => {
+		midiInput.removeEventListener("midimessage", this._onMIDIMessage as any);
+		this._liveInput.clear(this._getContext(midiInput));
+	}
+
+	private _getContext(midiInput: MIDIInput) {
+		return `midiInput:${midiInput.id}`;
+	}
+
+	private _onMIDIMessage = (event: MIDIMessageEvent) => {
+		const [eventType, key] = event.data;
+		const context = this._getContext(event.target);
+
+		switch(eventType) {
+			case MIDI_EVENT.NOTE_ON:
+				this._doc.synth.maintainLiveInput();
+				this._liveInput.addNote(key, context);
+				break;
+			case MIDI_EVENT.NOTE_OFF:
+				this._liveInput.removeNote(key, context);
+				break;
+		}
+	}
+}

--- a/editor/MidiInput.ts
+++ b/editor/MidiInput.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2012-2022 John Nesky and contributing authors, distributed under the MIT license, see accompanying the LICENSE.md file.
+
 import {SongDocument} from "./SongDocument";
 import {LiveInput} from "./LiveInput";
 import {MidiEventType} from "./Midi";

--- a/editor/MidiInput.ts
+++ b/editor/MidiInput.ts
@@ -71,13 +71,16 @@ export class MIDIInputHandler {
 			key = key % 12;
 		}
 
-		switch (true) {
-			case eventType == MidiEventType.noteOn && velocity > 0:
+		if (eventType == MidiEventType.noteOn && velocity == 0) {
+			eventType = MidiEventType.noteOff;
+		}
+
+		switch (eventType) {
+			case MidiEventType.noteOn:
 				this._doc.synth.maintainLiveInput();
 				this._liveInput.addNote(key);
 				break;
-			case eventType == MidiEventType.noteOff:
-			case eventType == MidiEventType.noteOn && velocity == 0:
+			case MidiEventType.noteOff:
 				this._liveInput.removeNote(key);
 				break;
 		}

--- a/editor/MidiInput.ts
+++ b/editor/MidiInput.ts
@@ -64,17 +64,20 @@ export class MIDIInputHandler {
 	private _onMIDIMessage = (event: MIDIMessageEvent) => {
 		const isDrum: boolean = this._doc.song.getChannelIsNoise(this._doc.channel);
 		const context = this._getContext(event.target);
-		let [eventType, key] = event.data;
+		let [eventType, key, velocity] = event.data;
+		eventType &= 0xF0;
+
 		if(isDrum) {
 			key = key % 12;
 		}
 
-		switch(eventType & 0xF0) {
-			case MidiEventType.noteOn:
+		switch(true) {
+			case eventType == MidiEventType.noteOn && velocity > 0:
 				this._doc.synth.maintainLiveInput();
 				this._liveInput.addNote(key, context);
 				break;
-			case MidiEventType.noteOff:
+			case eventType == MidiEventType.noteOff:
+			case eventType == MidiEventType.noteOn && velocity == 0:
 				this._liveInput.removeNote(key, context);
 				break;
 		}

--- a/editor/MidiInput.ts
+++ b/editor/MidiInput.ts
@@ -59,16 +59,11 @@ export class MIDIInputHandler {
 
 	private _unregisterMIDIInput = (midiInput: MIDIInput) => {
 		midiInput.removeEventListener("midimessage", this._onMIDIMessage as any);
-		this._liveInput.clear(this._getContext(midiInput));
-	}
-
-	private _getContext(midiInput: MIDIInput) {
-		return `midiInput:${midiInput.id}`;
+		this._liveInput.clear();
 	}
 
 	private _onMIDIMessage = (event: MIDIMessageEvent) => {
 		const isDrum: boolean = this._doc.song.getChannelIsNoise(this._doc.channel);
-		const context = this._getContext(event.target);
 		let [eventType, key, velocity] = event.data;
 		eventType &= 0xF0;
 
@@ -79,11 +74,11 @@ export class MIDIInputHandler {
 		switch (true) {
 			case eventType == MidiEventType.noteOn && velocity > 0:
 				this._doc.synth.maintainLiveInput();
-				this._liveInput.addNote(key, context);
+				this._liveInput.addNote(key);
 				break;
 			case eventType == MidiEventType.noteOff:
 			case eventType == MidiEventType.noteOn && velocity == 0:
-				this._liveInput.removeNote(key, context);
+				this._liveInput.removeNote(key);
 				break;
 		}
 	}

--- a/editor/MidiInput.ts
+++ b/editor/MidiInput.ts
@@ -28,22 +28,22 @@ export class MIDIInputHandler {
 		this.registerMIDIAccessHandler();
 	}
 	private async registerMIDIAccessHandler() {
-		if(navigator.requestMIDIAccess == null) return;
+		if (navigator.requestMIDIAccess == null) return;
 
 		try {
 			const midiAccess = await navigator.requestMIDIAccess();
 
 			midiAccess.inputs.forEach(this._registerMIDIInput);
 			midiAccess.addEventListener("statechange", this._handleStateChange);
-		} catch(e) {
+		} catch (e) {
 			console.error("Failed to get MIDI access", e);
 		}
 	}
 
 	private _handleStateChange = (event: MIDIConnectionEvent) => {
-		if(event.port.type !== "input") return;
+		if (event.port.type !== "input") return;
 		
-		switch(event.port.state) {
+		switch (event.port.state) {
 			case "connected":
 				this._registerMIDIInput(event.port);
 				break;
@@ -72,11 +72,11 @@ export class MIDIInputHandler {
 		let [eventType, key, velocity] = event.data;
 		eventType &= 0xF0;
 
-		if(isDrum) {
+		if (isDrum) {
 			key = key % 12;
 		}
 
-		switch(true) {
+		switch (true) {
 			case eventType == MidiEventType.noteOn && velocity > 0:
 				this._doc.synth.maintainLiveInput();
 				this._liveInput.addNote(key, context);

--- a/editor/MidiInput.ts
+++ b/editor/MidiInput.ts
@@ -1,10 +1,6 @@
 import {SongDocument} from "./SongDocument";
 import {LiveInput} from "./LiveInput";
-
-const enum MIDI_EVENT {
-	NOTE_ON = "9",
-	NOTE_OFF = "8",
-}
+import {MidiEventType} from "./Midi";
 
 interface MIDIInput extends EventTarget {
 	id: string;
@@ -73,12 +69,12 @@ export class MIDIInputHandler {
 			key = key % 12;
 		}
 
-		switch(eventType.toString(16)[0]) {
-			case MIDI_EVENT.NOTE_ON:
+		switch(eventType & 0xF0) {
+			case MidiEventType.noteOn:
 				this._doc.synth.maintainLiveInput();
 				this._liveInput.addNote(key, context);
 				break;
-			case MIDI_EVENT.NOTE_OFF:
+			case MidiEventType.noteOff:
 				this._liveInput.removeNote(key, context);
 				break;
 		}

--- a/editor/MidiInput.ts
+++ b/editor/MidiInput.ts
@@ -2,8 +2,8 @@ import {SongDocument} from "./SongDocument";
 import {LiveInput} from "./LiveInput";
 
 const enum MIDI_EVENT {
-	NOTE_ON = 144,
-	NOTE_OFF = 128,
+	NOTE_ON = "9",
+	NOTE_OFF = "8",
 }
 
 interface MIDIInput extends EventTarget {
@@ -17,7 +17,7 @@ interface MIDIConnectionEvent {
 }
 
 interface MIDIMessageEvent {
-	data: [type: MIDI_EVENT, key: number, velocity: number];
+	data: [type: number, key: number, velocity: number];
 	target: MIDIInput;
 }
 
@@ -66,10 +66,14 @@ export class MIDIInputHandler {
 	}
 
 	private _onMIDIMessage = (event: MIDIMessageEvent) => {
-		const [eventType, key] = event.data;
+		const isDrum: boolean = this._doc.song.getChannelIsNoise(this._doc.channel);
 		const context = this._getContext(event.target);
+		let [eventType, key] = event.data;
+		if(isDrum) {
+			key = key % 12;
+		}
 
-		switch(eventType) {
+		switch(eventType.toString(16)[0]) {
 			case MIDI_EVENT.NOTE_ON:
 				this._doc.synth.maintainLiveInput();
 				this._liveInput.addNote(key, context);

--- a/editor/Piano.ts
+++ b/editor/Piano.ts
@@ -84,13 +84,13 @@ export class Piano {
 		const octaveOffset: number = this._doc.getBaseVisibleOctave(this._doc.channel) * Config.pitchesPerOctave;
 		const currentPitch: number = this._cursorPitch + octaveOffset;
 		if (this._playedPitch == currentPitch) return;
-		this._liveInput.removeNote(this._playedPitch, "piano");
+		this._liveInput.removeNote(this._playedPitch);
 		this._playedPitch = currentPitch;
-		this._liveInput.addNote(currentPitch, "piano");
+		this._liveInput.addNote(currentPitch);
 	}
 	
 	private _releaseLiveInput(): void {
-		this._liveInput.removeNote(this._playedPitch, "piano");
+		this._liveInput.removeNote(this._playedPitch);
 		this._playedPitch = -1;
 	}
 	

--- a/editor/Piano.ts
+++ b/editor/Piano.ts
@@ -84,13 +84,13 @@ export class Piano {
 		const octaveOffset: number = this._doc.getBaseVisibleOctave(this._doc.channel) * Config.pitchesPerOctave;
 		const currentPitch: number = this._cursorPitch + octaveOffset;
 		if (this._playedPitch == currentPitch) return;
-		this._liveInput.removeNote(this._playedPitch);
+		this._liveInput.removeNote(this._playedPitch, "piano");
 		this._playedPitch = currentPitch;
-		this._liveInput.addNote(currentPitch);
+		this._liveInput.addNote(currentPitch, "piano");
 	}
 	
 	private _releaseLiveInput(): void {
-		this._liveInput.removeNote(this._playedPitch);
+		this._liveInput.removeNote(this._playedPitch, "piano");
 		this._playedPitch = -1;
 	}
 	

--- a/editor/SongEditor.ts
+++ b/editor/SongEditor.ts
@@ -22,6 +22,7 @@ import {HarmonicsEditor} from "./HarmonicsEditor";
 import {BarScrollBar} from "./BarScrollBar";
 import {OctaveScrollBar} from "./OctaveScrollBar";
 import {LiveInput} from "./LiveInput";
+import {MIDIInputHandler} from "./MidiInput";
 import {Piano} from "./Piano";
 import {BeatsPerBarPrompt} from "./BeatsPerBarPrompt";
 import {MoveNotesSidewaysPrompt} from "./MoveNotesSidewaysPrompt";
@@ -431,6 +432,7 @@ export class SongEditor {
 	
 	constructor(private _doc: SongDocument) {
 		this._doc.notifier.watch(this.whenUpdated);
+		new MIDIInputHandler(this._doc, this._liveInput);
 		window.addEventListener("resize", this.whenUpdated);
 		
 		if (!("share" in navigator)) {

--- a/editor/SongEditor.ts
+++ b/editor/SongEditor.ts
@@ -21,6 +21,7 @@ import {SpectrumEditor} from "./SpectrumEditor";
 import {HarmonicsEditor} from "./HarmonicsEditor";
 import {BarScrollBar} from "./BarScrollBar";
 import {OctaveScrollBar} from "./OctaveScrollBar";
+import {LiveInput} from "./LiveInput";
 import {Piano} from "./Piano";
 import {BeatsPerBarPrompt} from "./BeatsPerBarPrompt";
 import {MoveNotesSidewaysPrompt} from "./MoveNotesSidewaysPrompt";
@@ -126,7 +127,8 @@ export class SongEditor {
 	private readonly _trackEditor: TrackEditor = new TrackEditor(this._doc);
 	private readonly _loopEditor: LoopEditor = new LoopEditor(this._doc);
 	private readonly _octaveScrollBar: OctaveScrollBar = new OctaveScrollBar(this._doc);
-	private readonly _piano: Piano = new Piano(this._doc);
+	private readonly _liveInput: LiveInput = new LiveInput(this._doc);
+	private readonly _piano: Piano = new Piano(this._doc, this._liveInput);
 	private readonly _playButton: HTMLButtonElement = button({style: "width: 80px;", type: "button"});
 	private readonly _prevBarButton: HTMLButtonElement = button({class: "prevBarButton", style: "width: 40px;", type: "button", title: "Previous Bar (left bracket)"});
 	private readonly _nextBarButton: HTMLButtonElement = button({class: "nextBarButton", style: "width: 40px;", type: "button", title: "Next Bar (right bracket)"});


### PR DESCRIPTION
Hey!

This PR allows to use a connected MIDI device to play sounds similar to the on screen piano keys, but also allows to play chords instead of just single tones.

For now I just injected depencies through the constructor. If there is any kind of event system or similar to resolve these direct dependencies I will happily adapt that.
The classes were structured without much knowledge about the global domain model, so I would also appreciate feedback if I should restructure them.
I'm thinking about letting `LiveInput` handle the calls of `this._doc.synth.maintainLiveInput` using an interval. Would that be ok?

One thing to keep in mind: Midi events don't seem to allow the creation of AudioContexts (at least not in Chrome). Therefore the user has to play a sound through some kind of pointer event before being able to hear the midi sounds. So maybe it would be a good idea to let the user manually activate a midi device? That would maybe also be useful if the user uses multiple music softwares and doesn't want Beepbox to recognize a device.

This feature is currently only tested in Chrome with the AKAI MPK Mini (The only midi device I own). Firefox doesn't support the Web Midi API yet, but it seems Firefox 99 will support it. So we should also test it in FF before merging.