### PR TITLE
Increase instrument volumeRange from 8 to 24

### DIFF
--- a/synth/SynthConfig.ts
+++ b/synth/SynthConfig.ts
@@ -345,7 +345,7 @@ export class Config {
 	public static readonly effectNames: ReadonlyArray<string> = ["reverb", "chorus", "panning", "distortion", "bitcrusher", "note filter", "echo", "pitch shift", "detune", "vibrato", "transition type", "chord type"];
 	public static readonly effectOrder: ReadonlyArray<EffectType> = [EffectType.transition, EffectType.chord, EffectType.pitchShift, EffectType.detune, EffectType.vibrato, EffectType.noteFilter, EffectType.distortion, EffectType.bitcrusher, EffectType.panning, EffectType.chorus, EffectType.echo, EffectType.reverb];
 	public static readonly noteSizeMax: number = 3;
-	public static readonly volumeRange: number = 8;
+	public static readonly volumeRange: number = 24;
 	public static readonly volumeLogScale: number = -0.5;
 	public static readonly panCenter: number = 4;
 	public static readonly panMax: number = Config.panCenter * 2;


### PR DESCRIPTION
See #41. Instrument volume range is only about 8 ticks wide, and increasing the value would help balance instruments that have very different volumes. One example: I have a sawtooth wave (panning right) that is competing with a 1/8 pulse wave (panning left) -- if I increase one, the other is now too quiet. If I increase both to max, volumes are kinda fixed, but this makes every other instrument in the mix sound too quiet.