### PR TITLE
Allow importing files with uppercase file extension

### DIFF
--- a/editor/ImportPrompt.ts
+++ b/editor/ImportPrompt.ts
@@ -50,7 +50,7 @@ export class ImportPrompt implements Prompt {
 		const file: File = this._fileInput.files![0];
 		if (!file) return;
 		
-		const extension: string = file.name.slice((file.name.lastIndexOf(".") - 1 >>> 0) + 2);
+		const extension: string = file.name.slice((file.name.lastIndexOf(".") - 1 >>> 0) + 2).toLowerCase();
 		if (extension == "json") {
 			const reader: FileReader = new FileReader();
 			reader.addEventListener("load", (event: Event): void => {


### PR DESCRIPTION
This might not seem like a big deal, but importing MIDIs with an uppercase file extension - for example from [here](http://onj3.andrelouis.com/phonetones/unzipped/LG/GB102/) - would silently fail without any error message unless you check the browser console. 