### PR TITLE
Fix octave scrollbar desync. Issue #123

### DIFF
--- a/editor/PatternEditor.ts
+++ b/editor/PatternEditor.ts
@@ -1091,7 +1091,7 @@ export class PatternEditor {
 				const pattern2: Pattern | null = this._doc.song.getPattern(channel, this._doc.bar + this._barOffset);
 				if (pattern2 == null) continue;
 				
-				const octaveOffset: number = this._doc.getBaseVisibleOctave(channel) * Config.pitchesPerOctave;
+				const octaveOffset: number = this._doc.getBaseVisibleOctave(this._doc.channel) * Config.pitchesPerOctave;
 				for (const note of pattern2.notes) {
 					for (const pitch of note.pitches) {
 						const notePath: SVGPathElement = SVG.path();


### PR DESCRIPTION
Fixes #123 

With both Show Octave Scrollbar and Show All Channels turned on, the secondary channels should scroll according to the current scrollbar position, not their stored position.

The previous behavior had one benefit, which is that I could scroll the octave bar to a position, and then switch to another channel to use it as a visual reference. However, you can still do this and select + move the notes down if that's a need. What's far more important is, there was no good way to add chords between channels because you couldn't trust the pitch shown and now you can. It's also far less surprising user behavior to have all notes scroll. I believe this should fully replace the previous behavior.

https://github.com/user-attachments/assets/a01700ea-94b9-444b-8fa1-10657bf31e9d